### PR TITLE
[MJAR-238] Allow setting of module main class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
 
   <properties>
     <mavenArchiverVersion>3.3.0</mavenArchiverVersion>
+    <mavenFileManagementVersion>3.0.0</mavenFileManagementVersion>
     <mavenVersion>3.0</mavenVersion>
     <javaVersion>7</javaVersion>
   </properties>
@@ -95,6 +96,11 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
       <version>${mavenVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>file-management</artifactId>
+      <version>${mavenFileManagementVersion}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/src/it/MJAR-238-modular-jar-main-class/invoker.properties
+++ b/src/it/MJAR-238-modular-jar-main-class/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.java.version = 9+

--- a/src/it/MJAR-238-modular-jar-main-class/pom.xml
+++ b/src/it/MJAR-238-modular-jar-main-class/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>mjar-238-modular-jar-main-class</artifactId>
+  <name>mjar-238-modular-jar-main-class</name>
+  <description>Verifies that the modular descriptor main class is set for modular Jar files</description>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>myproject.HelloWorld</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <source>1.9</source>
+            <target>1.9</target>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/src/it/MJAR-238-modular-jar-main-class/src/main/java/module-info.java
+++ b/src/it/MJAR-238-modular-jar-main-class/src/main/java/module-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module myproject {
+    exports myproject;
+}

--- a/src/it/MJAR-238-modular-jar-main-class/src/main/java/myproject/HelloWorld.java
+++ b/src/it/MJAR-238-modular-jar-main-class/src/main/java/myproject/HelloWorld.java
@@ -1,0 +1,36 @@
+package myproject;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * The classic Hello World App.
+ */
+public class HelloWorld {
+
+  /**
+     * Main method.
+     *
+     * @param args Not used
+     */
+    public static void main( String[] args )
+    {
+        System.out.println( "Hi!" );
+    } 
+}

--- a/src/it/MJAR-238-modular-jar-main-class/verify.bsh
+++ b/src/it/MJAR-238-modular-jar-main-class/verify.bsh
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import java.lang.module.*;
+import java.util.jar.*;
+
+boolean result = true;
+JarFile jar;
+
+try
+{
+    File target = new File( basedir, "target" );
+    if ( !target.exists() || !target.isDirectory() )
+    {
+        System.err.println( "target file is missing or not a directory." );
+        return false;
+    }
+
+    File artifact = new File( target, "mjar-238-modular-jar-main-class-1.0-SNAPSHOT.jar" );
+    if ( !artifact.exists() || artifact.isDirectory() )
+    {
+        System.err.println( "artifact file is missing or a directory." );
+        return false;
+    }
+
+    jar = new JarFile( artifact );
+
+    Attributes manifest = jar.getManifest().getMainAttributes();
+
+    if ( !"myproject.HelloWorld".equals( manifest.get( Attributes.Name.MAIN_CLASS ) ) )
+    {
+        System.err.println( "Manifest main class attribute not equals myproject.HelloWorld" );
+        return false;
+    }
+
+    InputStream moduleDescriptorInputStream = jar.getInputStream( jar.getEntry( "module-info.class" ) );
+    ModuleDescriptor moduleDescriptor = ModuleDescriptor.read( moduleDescriptorInputStream );
+
+    if ( !"myproject.HelloWorld".equals( moduleDescriptor.mainClass().orElse( null ) ) )
+    {
+        System.err.println( "Module descriptor main class not equals myproject.HelloWorld" );
+        return false;
+    }
+}
+catch( Throwable e )
+{
+    e.printStackTrace();
+    result = false;
+}
+finally
+{
+    if ( jar != null )
+    {
+        jar.close();
+    }
+}
+
+return result;

--- a/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
@@ -28,10 +28,14 @@ import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
+import org.apache.maven.shared.model.fileset.FileSet;
+import org.apache.maven.shared.model.fileset.util.FileSetManager;
 import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.jar.JarArchiver;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.Map;
 
 /**
  * Base class for creating a jar from project classes.
@@ -46,6 +50,8 @@ public abstract class AbstractJarMojo
     private static final String[] DEFAULT_EXCLUDES = new String[] { "**/package.html" };
 
     private static final String[] DEFAULT_INCLUDES = new String[] { "**/**" };
+
+    private static final String MODULE_DESCRIPTOR_FILE_NAME = "module-info.class";
 
     /**
      * List of files to include. Specified as fileset patterns which are relative to the input directory whose contents
@@ -76,8 +82,8 @@ public abstract class AbstractJarMojo
     /**
      * The Jar archiver.
      */
-    @Component( role = Archiver.class, hint = "jar" )
-    private JarArchiver jarArchiver;
+    @Component
+    private Map<String, Archiver> archivers;
 
     /**
      * The {@link {MavenProject}.
@@ -201,9 +207,41 @@ public abstract class AbstractJarMojo
     {
         File jarFile = getJarFile( outputDirectory, finalName, getClassifier() );
 
+        FileSetManager fileSetManager = new FileSetManager();
+        FileSet jarContentFileSet = new FileSet();
+        jarContentFileSet.setDirectory( getClassesDirectory().getAbsolutePath() );
+        jarContentFileSet.setIncludes( Arrays.asList( getIncludes() ) );
+        jarContentFileSet.setExcludes( Arrays.asList( getExcludes() ) );
+
+        boolean containsModuleDescriptor = false;
+        String[] includedFiles = fileSetManager.getIncludedFiles( jarContentFileSet );
+        for ( String includedFile : includedFiles )
+        {
+            // May give false positives if the files is named as module descriptor
+            // but is not in the root of the archive or in the versioned area
+            // (and hence not actually a module descriptor).
+            // That is fine since the modular Jar archiver will gracefully
+            // handle such case.
+            // And also such case is unlikely to happen as file ending
+            // with "module-info.class" is unlikely to be included in Jar file
+            // unless it is a module descriptor.
+            if ( includedFile.endsWith( MODULE_DESCRIPTOR_FILE_NAME ) )
+            {
+                containsModuleDescriptor = true;
+                break;
+            }
+        }
+
         MavenArchiver archiver = new MavenArchiver();
 
-        archiver.setArchiver( jarArchiver );
+        if ( containsModuleDescriptor )
+        {
+            archiver.setArchiver( (JarArchiver) archivers.get( "mjar" ) );
+        }
+        else
+        {
+            archiver.setArchiver( (JarArchiver) archivers.get( "jar" ) );
+        }
 
         archiver.setOutputFile( jarFile );
 

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -78,3 +78,22 @@ mvn package
   the {{{/guides/introduction/introduction-to-the-lifecycle.html}Maven Build Life Cycle}}.
 
   For full documentation, click {{{./plugin-info.html}here}}.
+
+* Modular JAR files
+
+  The {{{https://openjdk.java.net/projects/jigsaw/spec/}Java Platform Module System (JPMS)}} introduced
+  {{{https://cr.openjdk.java.net/~mr/jigsaw/spec/jar.html}changes in the JAR file specifications}}
+  as well - Modular JAR files. Modular JAR files are JAR files with <<<module-info.class>>> file in the root directory
+  (or in the versioned area for multi-release JAR files). If the project contains <<<module-info.class>>>
+  the resulting JAR will be a Modular JAR without a need for any configuration regardless of the plugin version used.
+
+  Starting with version 3.1.2, if the JAR file contains <<<module-info.class>>>, this plugin will update
+  the modular descriptor (<<<module-info.class>>>) with additional attributes such as the list of packages included
+  and will validate the resulting modular descriptor (for example if all services provided by the module are actually
+  included in the JAR file). The most notable additional attribute added is the module main class.
+  If the JAR manifest contains <<<Main-Class>>> attribute this plugin will set the module main class to the same value
+  (for example how to set it read {{{../../shared/maven-archiver/examples/classpath.html}Make The Jar Executable}}).
+  Internally the plugin uses the JDK <<<jar>>> tool so in order to add the additional attributes and to
+  verify the modular descriptor Maven should be run with JDK version 9 or newer. If version 8 or earlier is used
+  the resulting JAR still will be Modular JAR (as it contains <<<module-info.class>>>) but no additional attributes
+  will be added and no validation will be performed.


### PR DESCRIPTION
This pull request adds support for modular JAR files. Of course it was possible to create JAR files that contains `module-info.class` but the `jar` tools part of the JDK does more that that. It allows the module main class and version to be specified, adds the list of the packages included in the module and verifies that the module descriptor is correct.

This PR modifies the JAR plugin to use the new `ModularJarArchiver` so the above mentioned information can be added to the module descriptor as well to the validated.  `ModularJarArchiver` handles gracefully non-modular JAR archives so it is safe to be used for all JAR files without prior knowledge if the archive is going to contain `module-info.class` or not.

 `ModularJarArchiver` requires the JDK used to run Maven to be 9 or newer in order to modify the module descriptor as the current implementation (`JarToolModularJarArchiver`) uses the JDK `jar` tool and does not support tool chains. If the JDK used is 8 or older then `ModularJarArchiver` will gracefully fallback to treating the archive as regular JAR file and will just pack the module descriptor without modifying or validating it.

The current implementation does not allow the user to specify the module version, but that is not a problem as it is set by the compiler plugin. And if needed could easily be added later - `ModularJarArchiver` already support specifying the module version.


 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
