### PR TITLE
update minimum Maven version to 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
   <properties>
     <mavenFileManagementVersion>3.0.0</mavenFileManagementVersion>
     <mavenArchiverVersion>3.5.0</mavenArchiverVersion>
-    <mavenVersion>3.0</mavenVersion>
+    <mavenVersion>3.1.0</mavenVersion>
     <javaVersion>7</javaVersion>
     <project.build.outputTimestamp>2020-04-07T21:04:00Z</project.build.outputTimestamp>
   </properties>
@@ -150,7 +150,13 @@
     <dependency>
       <groupId>org.apache.maven.plugin-testing</groupId>
       <artifactId>maven-plugin-testing-harness</artifactId>
-      <version>2.1</version>
+      <version>3.1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-compat</artifactId>
+      <version>${mavenVersion}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
@ian-lavallee @rfscholte I can update the minimum Maven version here to 3.1.0, but to do this I have to dd maven-compat back in, at least for tests. Can anyone see how I might do this without maven-compat? When I try I tend to get errors like

WARNING: Error injecting: org.apache.maven.repository.legacy.LegacyRepositorySystem
java.lang.NoClassDefFoundError: org/sonatype/aether/RepositorySystemSession

That is, something is still asking for Sonatype Aether. It's not immediately obvious to me where/how the binding for RepositorySystemSession is set. 