### PR TITLE
Updated create-test-jar.apt.vm removing 'and' in Maven site Create Test JAR documentation

### DIFF
--- a/src/site/apt/examples/create-test-jar.apt.vm
+++ b/src/site/apt/examples/create-test-jar.apt.vm
@@ -113,7 +113,7 @@ How to create a jar containing test classes
      the original project to the <<<src/main/java>>> of this project.
      The same type of movement counts for the resources as well of course.
    
-   * Move the required <<<test>>>-scoped dependencies and from the original 
+   * Move the required <<<test>>>-scoped dependencies from the original 
      project to this project and remove the scope (i.e. changing it to the <<<compile>>>-scope).
      And yes, that means that the junit dependency (or any other testing 
      framework dependency) gets the default scope too. You'll probably need 


### PR DESCRIPTION
Updates create-test-jar.apt.vm removing 'and' which was either missing something additional to the test-scoped dependencies or was left unintentionally. No JIRA issues linked because this is a trivial change similar to a typo making up for a better example description.

Improves the description on the Maven site here: https://maven.apache.org/plugins/maven-jar-plugin/examples/create-test-jar.html

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

