### PR TITLE
[MJAR-275] - Fix outputTimestamp not applied to module-info; breaks reproducible builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,11 +121,6 @@
       <artifactId>maven-plugin-annotations</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-archiver</artifactId>
-      <version>4.3.0</version>
-    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/src/it/MJAR-275-reproducible-module-info/invoker.properties
+++ b/src/it/MJAR-275-reproducible-module-info/invoker.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# NOTE: Requires Java 10+ to compile the module declaration for Java 9+,
+# this is due that compiling the module declaration generates a
+# module descriptor with the JDK version on it, making it unreproducible.
+invoker.java.version = 10+

--- a/src/it/MJAR-275-reproducible-module-info/pom.xml
+++ b/src/it/MJAR-275-reproducible-module-info/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>mjar-275-reproducible-multi-release-modular-jar</artifactId>
+  <name>mjar-275-reproducible-multi-release-modular-jar</name>
+  <description>Verifies that the modular descriptor is reproducible (timestamp is set)</description>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.outputTimestamp>2022-06-26T13:25:58Z</project.build.outputTimestamp>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>myproject.HelloWorld</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.10.1</version>
+          <configuration>
+            <release>8</release>
+          </configuration>
+          <executions>
+            <execution>
+              <id>java9</id>
+              <goals>
+                <goal>compile</goal>
+              </goals>
+              <configuration>
+                <release>9</release>
+                <compileSourceRoots>
+                  <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
+                </compileSourceRoots>
+                <multiReleaseOutput>true</multiReleaseOutput>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/src/it/MJAR-275-reproducible-module-info/src/main/java/myproject/HelloWorld.java
+++ b/src/it/MJAR-275-reproducible-module-info/src/main/java/myproject/HelloWorld.java
@@ -1,0 +1,37 @@
+package myproject;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * The classic Hello World App.
+ */
+public class HelloWorld
+{
+
+    /**
+     * Main method.
+     *
+     * @param args Not used
+     */
+    public static void main( String[] args )
+    {
+        System.out.println( "Hi!" );
+    }
+}

--- a/src/it/MJAR-275-reproducible-module-info/src/main/java9/module-info.java
+++ b/src/it/MJAR-275-reproducible-module-info/src/main/java9/module-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module myproject {
+    exports myproject;
+}

--- a/src/it/MJAR-275-reproducible-module-info/verify.groovy
+++ b/src/it/MJAR-275-reproducible-module-info/verify.groovy
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import java.lang.module.*;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.util.*;
+import java.util.jar.*;
+
+File target = new File( basedir, "target" )
+
+assert target.exists()
+assert target.isDirectory()
+
+File artifact = new File( target, "mjar-275-reproducible-multi-release-modular-jar-1.0-SNAPSHOT.jar" );
+
+assert artifact.exists()
+assert artifact.isFile()
+
+JarFile jar = new JarFile( artifact );
+
+Attributes manifest = jar.getManifest().getMainAttributes();
+
+assert "myproject.HelloWorld".equals( manifest.get( Attributes.Name.MAIN_CLASS ) )
+
+InputStream moduleDescriptorInputStream = jar.getInputStream( jar.getEntry( "META-INF/versions/9/module-info.class" ) );
+ModuleDescriptor moduleDescriptor = ModuleDescriptor.read( moduleDescriptorInputStream );
+
+assert "myproject.HelloWorld".equals( moduleDescriptor.mainClass().orElse( null ) )
+
+// Normalize to UTC
+long normalizeUTC( String timestamp )
+{
+  long millis = Instant.parse( timestamp ).toEpochMilli();
+  Calendar cal = Calendar.getInstance();
+  cal.setTimeInMillis( millis );
+  return millis - ( cal.get( Calendar.ZONE_OFFSET ) + cal.get( Calendar.DST_OFFSET ) );
+}
+
+// All entries should have the same timestamp
+FileTime expectedTimestamp = FileTime.fromMillis( normalizeUTC( "2022-06-26T13:25:58Z" ) );
+Enumeration<JarEntry> entries = jar.entries();
+while ( entries.hasMoreElements() )
+{
+    assert expectedTimestamp.equals( entries.nextElement().getLastModifiedTime() )
+}
+
+jar.close();

--- a/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
@@ -141,9 +141,10 @@ public abstract class AbstractJarMojo
     private boolean skipIfEmpty;
 
     /**
-     * Timestamp for reproducible output archive entries, either formatted as ISO 8601
-     * <code>yyyy-MM-dd'T'HH:mm:ssXXX</code> or as an int representing seconds since the epoch (like
-     * <a href="https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH</a>).
+     * Timestamp for reproducible output archive entries, either formatted as ISO 8601 extended offset date-time
+     * (e.g. in UTC such as '2011-12-03T10:15:30Z' or with an offset '2019-10-05T20:37:42+06:00'),
+     * or as an int representing seconds since the epoch
+     * (like <a href="https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH</a>).
      *
      * @since 3.2.0
      */
@@ -257,7 +258,7 @@ public abstract class AbstractJarMojo
         archiver.setOutputFile( jarFile );
 
         // configure for Reproducible Builds based on outputTimestamp value
-        archiver.configureReproducible( outputTimestamp );
+        archiver.configureReproducibleBuild( outputTimestamp );
 
         archive.setForced( forceCreation );
 


### PR DESCRIPTION
This requires the release of plexus-archiver 4.3.0 and maven-archiver 3.6.0.

Fixing the "[MJAR-275 - outputTimestamp not applied to module-info; breaks reproducible builds](https://issues.apache.org/jira/browse/MJAR-275)"


Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MJAR) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MJAR-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJAR-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [X] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [X] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

