### PR TITLE
Code simplifications in AbstractMojo

### DIFF
--- a/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
@@ -322,14 +322,12 @@ public abstract class AbstractJarMojo
 
     private boolean projectHasAlreadySetAnArtifact()
     {
-        if ( getProject().getArtifact().getFile() != null )
-        {
-            return getProject().getArtifact().getFile().isFile();
-        }
-        else
+        if ( getProject().getArtifact().getFile() == null )
         {
             return false;
         }
+
+        return getProject().getArtifact().getFile().isFile();
     }
 
     /**

--- a/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
@@ -335,13 +335,7 @@ public abstract class AbstractJarMojo
      */
     protected boolean hasClassifier()
     {
-        boolean result = false;
-        if ( getClassifier() != null && getClassifier().trim().length() > 0 )
-        {
-            result = true;
-        }
-
-        return result;
+        return getClassifier() != null && getClassifier().trim().length() > 0;
     }
 
     private String[] getIncludes()

--- a/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
@@ -244,18 +244,11 @@ public abstract class AbstractJarMojo
             }
         }
 
+        String archiverName = containsModuleDescriptor ? "mjar" : "jar";
+
         MavenArchiver archiver = new MavenArchiver();
         archiver.setCreatedBy( "Maven JAR Plugin", "org.apache.maven.plugins", "maven-jar-plugin" );
-
-        if ( containsModuleDescriptor )
-        {
-            archiver.setArchiver( (JarArchiver) archivers.get( "mjar" ) );
-        }
-        else
-        {
-            archiver.setArchiver( (JarArchiver) archivers.get( "jar" ) );
-        }
-
+        archiver.setArchiver( (JarArchiver) archivers.get( archiverName ) );
         archiver.setOutputFile( jarFile );
 
         // configure for Reproducible Builds based on outputTimestamp value

--- a/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
@@ -196,16 +196,17 @@ public abstract class AbstractJarMojo
             throw new IllegalArgumentException( "finalName is not allowed to be null" );
         }
 
-        StringBuilder fileName = new StringBuilder( resultFinalName );
-
+        String fileName;
         if ( hasClassifier() )
         {
-            fileName.append( "-" ).append( classifier );
+            fileName = resultFinalName + "-" + classifier + ".jar";
+        }
+        else
+        {
+            fileName = resultFinalName + ".jar";
         }
 
-        fileName.append( ".jar" );
-
-        return new File( basedir, fileName.toString() );
+        return new File( basedir, fileName );
     }
 
     /**


### PR DESCRIPTION
Clean up a few overly-verbose code constructs:

- Replace an unnecessary use of `StringBuilder` with string concatenation.
- Remove some code duplication when selecting which archiver to use.
- Eliminate an `else` branch by returning early in `AbstractMojo#projectHasAlreadySetAnArtifact()`
- Remove an unnecessary local variable in `AbstractMojo#hasClassifier()`