### PR TITLE
[MJAR-310] - fixed toolchain version detection when toolchain paths contain white spaces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,10 +132,6 @@
     <!-- plexus -->
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
       <version>4.9.2</version>
     </dependency>


### PR DESCRIPTION
Switched to `ProcessBuilder` for JDK toolchain version detection as it actually correctly handles white spaces in the executable path compared to the plexus-utils dependency.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
