### PR TITLE
Add warning in strange case

### DIFF
--- a/src/it/MNG-8137/invoker.properties
+++ b/src/it/MNG-8137/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = jar:jar

--- a/src/it/MNG-8137/pom.xml
+++ b/src/it/MNG-8137/pom.xml
@@ -1,0 +1,42 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.jar.it</groupId>
+  <artifactId>mng-8137</artifactId>
+  <packaging>pom</packaging>
+  <version>1.0</version>
+  <name>it-mng-8137</name>
+
+  <description>Project w/ pom packaging and jar:jar invoked</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>@project.version@</version>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/MNG-8137/verify.groovy
+++ b/src/it/MNG-8137/verify.groovy
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+String log = new File(basedir, 'build.log').text
+assert log.contains('[WARNING] Language of project is \'none\', this is most probably not what you want')

--- a/src/it/MNG-8137/verify.groovy
+++ b/src/it/MNG-8137/verify.groovy
@@ -18,4 +18,4 @@
  */
 
 String log = new File(basedir, 'build.log').text
-assert log.contains('[WARNING] Language of project is \'none\', this is most probably not what you want')
+assert log.contains('[WARNING] The project packaging language is NOT \'java\'; this is most probably not what you want')

--- a/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
@@ -22,12 +22,11 @@ import java.io.File;
 import java.nio.file.FileSystems;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.maven.archiver.MavenArchiveConfiguration;
 import org.apache.maven.archiver.MavenArchiver;
-import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -132,8 +131,8 @@ public abstract class AbstractJarMojo extends AbstractMojo {
     @Component
     private MavenProjectHelper projectHelper;
 
-    @Component(hint = "pom")
-    private ArtifactHandler pomArtifactHandler;
+    @Component
+    private ArtifactHandlerManager artifactHandlerManager;
 
     /**
      * Require the jar plugin to build a new JAR even if none of the contents appear to have changed. By default, this
@@ -356,11 +355,13 @@ public abstract class AbstractJarMojo extends AbstractMojo {
                     throw new MojoExecutionException("You have to use a classifier "
                             + "to attach supplemental artifacts to the project instead of replacing them.");
                 }
-                if (Objects.equals(
-                        pomArtifactHandler.getLanguage(),
-                        getProject().getArtifact().getArtifactHandler().getLanguage())) {
-                    getLog().warn("Language of project is '" + pomArtifactHandler.getLanguage()
-                            + "', this is most probably not what you want");
+
+                if (!"java"
+                        .equals(artifactHandlerManager
+                                .getArtifactHandler(getProject().getPackaging())
+                                .getLanguage())) {
+                    getLog().warn(
+                                    "The project packaging language is NOT 'java'; this is most probably not what you want");
                 }
                 getProject().getArtifact().setFile(jarFile);
             }

--- a/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
@@ -22,10 +22,12 @@ import java.io.File;
 import java.nio.file.FileSystems;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.maven.archiver.MavenArchiveConfiguration;
 import org.apache.maven.archiver.MavenArchiver;
+import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -129,6 +131,9 @@ public abstract class AbstractJarMojo extends AbstractMojo {
      */
     @Component
     private MavenProjectHelper projectHelper;
+
+    @Component(hint = "pom")
+    private ArtifactHandler pomArtifactHandler;
 
     /**
      * Require the jar plugin to build a new JAR even if none of the contents appear to have changed. By default, this
@@ -350,6 +355,12 @@ public abstract class AbstractJarMojo extends AbstractMojo {
                 if (projectHasAlreadySetAnArtifact()) {
                     throw new MojoExecutionException("You have to use a classifier "
                             + "to attach supplemental artifacts to the project instead of replacing them.");
+                }
+                if (Objects.equals(
+                        pomArtifactHandler.getLanguage(),
+                        getProject().getArtifact().getArtifactHandler().getLanguage())) {
+                    getLog().warn("Language of project is '" + pomArtifactHandler.getLanguage()
+                            + "', this is most probably not what you want");
                 }
                 getProject().getArtifact().setFile(jarFile);
             }


### PR DESCRIPTION
The least we can do: check is "language" of current project packaging is "java" or not (all jar-like outputs are using language="java", only pom and bom packaging uses language="none"), and emit a WARN to user to reconsider.