### PR TITLE
Bump m-invoker-p to 3.9.1 for Java 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,9 @@
     <javaVersion>8</javaVersion>
     <mavenVersion>3.9.11</mavenVersion>
     <mavenArchiverVersion>3.6.4</mavenArchiverVersion>
+
+    <!-- for JDK 25 -->
+    <version.maven-invoker-plugin>3.9.1</version.maven-invoker-plugin>
     <project.build.outputTimestamp>2024-06-16T12:09:50Z</project.build.outputTimestamp>
   </properties>
 


### PR DESCRIPTION
fixes issue in ITs with JDK 25 seen when testing #465 

```
Running post-build script: /home/runner/work/maven-jar-plugin/maven-jar-plugin/target/it/MJAR-30-fullcontent/verify.groovy
BUG! exception in phase 'semantic analysis' in source unit 'Script1.groovy' Unsupported class file major version 69
	at org.codehaus.groovy.control.CompilationUnit$ISourceUnitOperation.doPhaseOperation(CompilationUnit.java:901)
	at org.codehaus.groovy.control.CompilationUnit.processPhaseOperations(CompilationUnit.java:692)
	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:666)
	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:365)
	at groovy.lang.GroovyClassLoader.lambda$parseClass$2(GroovyClassLoader.java:314)
```