### PR TITLE
Add new "attach" configuration parameter (3.x port of #482)

### DIFF
--- a/src/it/test-jar-attach/invoker.properties
+++ b/src/it/test-jar-attach/invoker.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+invoker.java.version = 10+
+
+invoker.name = Test Jar Attachment
+invoker.description = Verifies that setting the attach property to false will not install it in the local repository
+invoker.goals = clean install

--- a/src/it/test-jar-attach/pom.xml
+++ b/src/it/test-jar-attach/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>test-jar-attach</artifactId>
+    <name>test-jar-attach</name>
+    <description>Verifies that setting the attach property to false will not install it in the local repository
+    </description>
+    <packaging>jar</packaging>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.outputTimestamp>2023-11-19T13:25:58Z</project.build.outputTimestamp>
+    </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <skipIfEmpty>true</skipIfEmpty>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <configuration>
+                            <attach>false</attach>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/test-jar-attach/src/main/java/Foo.java
+++ b/src/it/test-jar-attach/src/main/java/Foo.java
@@ -1,0 +1,31 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Hello world!
+ *
+ */
+public class Foo
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+    }
+}

--- a/src/it/test-jar-attach/src/test/java/Foo.java
+++ b/src/it/test-jar-attach/src/test/java/Foo.java
@@ -1,0 +1,31 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Hello world!
+ *
+ */
+public class Foo
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+    }
+}

--- a/src/it/test-jar-attach/verify.groovy
+++ b/src/it/test-jar-attach/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def localRepo = basedir.getParentFile().getParentFile().getParentFile().getPath() + "/target/local-repo";
+
+def artifact = new File(localRepo, "org/apache/maven/plugins/test-jar-attach/1.0-SNAPSHOT/test-jar-attach-1.0-SNAPSHOT-tests.jar")
+assert !artifact.exists()

--- a/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
@@ -203,6 +203,14 @@ public abstract class AbstractJarMojo extends AbstractMojo {
     private boolean addDefaultExcludes;
 
     /**
+     * Specifies whether to attach the jar to the project
+     *
+     * @since 3.5.0
+     */
+    @Parameter(property = "maven.jar.attach", defaultValue = "true")
+    protected boolean attach;
+
+    /**
      * Return the specific output directory to serve as the root for the archive.
      * @return get classes directory.
      */
@@ -344,14 +352,18 @@ public abstract class AbstractJarMojo extends AbstractMojo {
         } else {
             File jarFile = createArchive();
 
-            if (hasClassifier()) {
-                projectHelper.attachArtifact(getProject(), getType(), getClassifier(), jarFile);
-            } else {
-                if (projectHasAlreadySetAnArtifact()) {
-                    throw new MojoExecutionException("You have to use a classifier "
-                            + "to attach supplemental artifacts to the project instead of replacing them.");
+            if (attach) {
+                if (hasClassifier()) {
+                    projectHelper.attachArtifact(getProject(), getType(), getClassifier(), jarFile);
+                } else {
+                    if (projectHasAlreadySetAnArtifact()) {
+                        throw new MojoExecutionException("You have to use a classifier "
+                                + "to attach supplemental artifacts to the project instead of replacing them.");
+                    }
+                    getProject().getArtifact().setFile(jarFile);
                 }
-                getProject().getArtifact().setFile(jarFile);
+            } else {
+                getLog().debug("Skipping attachment of the " + getType() + " artifact to the project.");
             }
         }
     }


### PR DESCRIPTION
This matches the `attach` parameter from the source plugin

Setting this parameter to `false` will skip attaching the generated jar artifact to the build. It will not be picked up by the install and deploy goals.

Omitting or setting this parameter to `true` will attach the jar to the build. This is the default behavior.

The use case for this is generating test jars as part of a build to be used in integration tests while they should not actually be deployed to a repository.

