### PR TITLE
Respect addBuildEnvironmentEntries for Build-Jdk-Spec

### DIFF
--- a/src/it/MJAR-539-build-environment-entries/pom.xml
+++ b/src/it/MJAR-539-build-environment-entries/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>mjar-539-build-environment-entries</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>mjar-539-build-environment-entries</name>
+
+  <properties>
+    <maven.compiler.release>11</maven.compiler.release>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <addBuildEnvironmentEntries>false</addBuildEnvironmentEntries>
+              <mainClass>myproject.HelloWorld</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/MJAR-539-build-environment-entries/src/main/java/module-info.java
+++ b/src/it/MJAR-539-build-environment-entries/src/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module org.apache.maven.plugins.jar.it.mjar539 {
+    exports myproject;
+}

--- a/src/it/MJAR-539-build-environment-entries/src/main/java/myproject/HelloWorld.java
+++ b/src/it/MJAR-539-build-environment-entries/src/main/java/myproject/HelloWorld.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package myproject;
+
+public class HelloWorld {
+    public static void main(String[] args) {}
+}

--- a/src/it/MJAR-539-build-environment-entries/verify.groovy
+++ b/src/it/MJAR-539-build-environment-entries/verify.groovy
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.jar.*;
+
+File target = new File( basedir, "target" );
+assert target.exists()
+assert target.isDirectory()
+
+File artifact = new File( target, "mjar-539-build-environment-entries-1.0-SNAPSHOT.jar" );
+assert artifact.exists()
+assert artifact.isFile()
+
+JarFile jar = new JarFile( artifact );
+Attributes manifest = jar.getManifest().getMainAttributes();
+
+assert "myproject.HelloWorld".equals( manifest.get( Attributes.Name.MAIN_CLASS ) )
+assert manifest.getValue( "Build-Jdk-Spec" ) == null
+assert manifest.getValue( "Build-Tool" ) == null
+assert manifest.getValue( "Build-Jdk" ) == null
+assert manifest.getValue( "Build-Os" ) == null
+assert manifest.getValue( "Build-Tool-Jdk-Spec" ) == null
+
+jar.close();

--- a/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
@@ -266,6 +266,7 @@ public abstract class AbstractJarMojo implements org.apache.maven.api.plugin.Moj
 
         MavenArchiver archiver = new MavenArchiver();
         archiver.setCreatedBy("Maven JAR Plugin", "org.apache.maven.plugins", "maven-jar-plugin");
+        archiver.setBuildJdkSpecDefaultEntry(archive.getManifest().isAddBuildEnvironmentEntries());
         archiver.setArchiver((JarArchiver) archivers.get(archiverName));
         archiver.setOutputFile(jarFile.toFile());
 


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Fixes #539.

## Summary

This makes the JAR plugin pass `archive.manifest.addBuildEnvironmentEntries` through to Maven Archiver's `Build-Jdk-Spec` default-entry switch.

When build environment entries are disabled, `Build-Jdk-Spec` is now omitted along with the other build-environment manifest entries. Normal manifest entries such as `Main-Class` and the detected `Java-Version` remain in place.

## Tests

- `mvn -Prun-its -Dinvoker.test=MJAR-539-build-environment-entries verify`
- `mvn verify`
- `mvn -Prun-its verify`