### PR TITLE
Remove unused declared dependencies, suppress false positive for guice

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,18 +133,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-api-xml</artifactId>
-      <version>${mavenVersion}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-xml</artifactId>
-      <version>${mavenVersion}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>file-management</artifactId>
       <version>${mavenFileManagementVersion}</version>
@@ -169,12 +157,6 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-testing</artifactId>
-      <version>${mavenVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-core</artifactId>
       <version>${mavenVersion}</version>
       <scope>test</scope>
     </dependency>
@@ -204,6 +186,15 @@
                 <include>**/pom.xml</include>
               </includes>
             </pom>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <configuration>
+            <ignoredUnusedDeclaredDependencies>
+              <ignoredUnusedDeclaredDependency>com.google.inject:guice:classes</ignoredUnusedDeclaredDependency>
+            </ignoredUnusedDeclaredDependencies>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
## Summary

`mvn dependency:analyze` reports 4 unused declared dependencies. Three are genuinely unused and can be removed. The fourth (guice) is a false positive required by the test harness.

## Changes

**Removed (3):**
- `maven-api-xml:provided` — no code references; already transitive via `maven-api-core`
- `maven-xml:provided` — no code references; already transitive via `maven-testing`
- `maven-core:test` — no code references; already transitive via `maven-testing`

**Kept with suppression (1):**
- `guice:test` — false positive. Required at test runtime by Eclipse Sisu (used by maven-testing harness for DI). Test-scope transitive deps at provided scope are excluded per Maven's scope table, so guice must be declared explicitly. Added to `<ignoredUnusedDeclaredDependencies>`.

## Verification
- No imports from any of the 4 packages exist in the project source code
- Each removed dependency is already available transitively through other declared dependencies
- guice suppression is scoped to the `:classes` classifier