### PR TITLE
Narrow catch clause in createArchive()

### DIFF
--- a/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
@@ -42,6 +42,7 @@ import org.apache.maven.shared.archiver.MavenArchiverException;
 import org.apache.maven.shared.model.fileset.FileSet;
 import org.apache.maven.shared.model.fileset.util.FileSetManager;
 import org.codehaus.plexus.archiver.Archiver;
+import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.jar.JarArchiver;
 
 /**
@@ -288,8 +289,7 @@ public abstract class AbstractJarMojo implements org.apache.maven.api.plugin.Moj
             archiver.createArchive(session, project, archive);
 
             return jarFile;
-        } catch (Exception e) {
-            // TODO: improve error handling
+        } catch (MavenArchiverException | ArchiverException e) {
             throw new MojoException("Error assembling JAR", e);
         }
     }


### PR DESCRIPTION
Fixes #559

Replaces the broad `catch (Exception e)` in `createArchive()` with `catch (MavenArchiverException | ArchiverException e)`, which are the specific checked exceptions declared by `MavenArchiver.createArchive()`. The `// TODO: improve error handling` comment is removed since the exception type is now correctly scoped.
