### PR TITLE
Manage commons-io via dependencyManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,17 @@
     <version.maven-toolchains-plugin>3.1.0</version.maven-toolchains-plugin>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <!-- align commons-io: file-management pulls 2.19.0, plexus-archiver needs 2.22.0 -->
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>2.22.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!-- Maven Core -->
     <dependency>
@@ -141,13 +152,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.36</version>
-    </dependency>
-
-    <!-- we need for Maven rc-3, looks like dependencyManagement is not taken into account -->
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.22.0</version>
     </dependency>
 
     <!-- Test -->


### PR DESCRIPTION
The 3.x line declares `commons-io:commons-io:2.22.0` as a direct compile dependency although nothing in the code uses it, so every build emits:

```
[WARNING] Unused declared dependencies found: commons-io:commons-io:jar:2.22.0:compile
```

The POM comment marks it as a Maven 4.0.0-rc-3-era workaround ("looks like dependencyManagement is not taken into account"). That behaviour is gone: `dependencyManagement` is honored by current Maven 3 and 4.

Note the pin itself is still required — simply removing the dependency silently *downgrades* commons-io: `org.apache.maven.shared:file-management:3.2.0 → commons-io:2.19.0` wins first-declaration conflict resolution against `plexus-archiver:4.12.0 → commons-io:2.22.0` (both depth 2), while plexus-archiver 4.12.0 expects 2.22.0. This PR therefore moves the pin into `<dependencyManagement>` instead of dropping it.

Verified (found while verifying the 3.5.1 release candidate):
* `dependency:tree -Dincludes=commons-io` resolves 2.22.0 with both Maven 3.10.0-rc-1 and Maven 4.0.0-rc-5 — effective classpath unchanged.
* `mvn clean verify -P run-its` green on both Maven lines: 38/38 ITs (incl. the toolchain-gated ones), `dependency:analyze` warning gone.

Dependabot keeps bumping the version in `dependencyManagement` as before.