### PR TITLE
Add integration test for multi-release JAR detection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,7 @@
               -->
               <exclude>src/it/mjar-71-01/src/main/resources/META-INF/MANIFEST.MF</exclude>
               <exclude>src/it/mjar-71-02/src/main/resources/META-INF/MANIFEST.MF</exclude>
+              <exclude>src/it/MJAR-557-detect-mjar/src/main/resources/META-INF/versions/9/test.txt</exclude>
             </excludes>
           </configuration>
         </plugin>

--- a/src/it/MJAR-557-detect-mjar/invoker.properties
+++ b/src/it/MJAR-557-detect-mjar/invoker.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+invoker.java.version = 9+
+invoker.name = MJAR-557 Detect MRJAR on Windows
+invoker.description = Checks the Multi-Release attribute is true when META-INF/versions/ is present

--- a/src/it/MJAR-557-detect-mjar/pom.xml
+++ b/src/it/MJAR-557-detect-mjar/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>mjar-557-detect-multi-release</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>MJAR-557 Multi-release JAR detection on Windows</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>@project.version@</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/MJAR-557-detect-mjar/src/main/resources/META-INF/versions/9/test.txt
+++ b/src/it/MJAR-557-detect-mjar/src/main/resources/META-INF/versions/9/test.txt
@@ -1,0 +1,1 @@
+Test file for multi-release JAR detection

--- a/src/it/MJAR-557-detect-mjar/verify.groovy
+++ b/src/it/MJAR-557-detect-mjar/verify.groovy
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.jar.*;
+
+def jarFile = new File(basedir, 'target/mjar-557-detect-multi-release-1.0-SNAPSHOT.jar')
+assert jarFile.exists()
+assert jarFile.isFile()
+
+def mrjar = new JarFile(jarFile)
+def manifest = mrjar.manifest.mainAttributes
+
+assert manifest.getValue(Attributes.Name.MULTI_RELEASE) == "true"

--- a/src/it/MJAR-557-detect-mjar/verify.groovy
+++ b/src/it/MJAR-557-detect-mjar/verify.groovy
@@ -17,13 +17,14 @@
  * under the License.
  */
 
-import java.util.jar.*;
+import java.util.jar.*
 
 def jarFile = new File(basedir, 'target/mjar-557-detect-multi-release-1.0-SNAPSHOT.jar')
 assert jarFile.exists()
 assert jarFile.isFile()
 
-def mrjar = new JarFile(jarFile)
-def manifest = mrjar.manifest.mainAttributes
-
-assert manifest.getValue(Attributes.Name.MULTI_RELEASE) == "true"
+new JarFile(jarFile).withCloseable { mrjar ->
+    def manifest = mrjar.manifest.mainAttributes
+    assert manifest.getValue(Attributes.Name.MULTI_RELEASE) == "true",
+        "Expected Multi-Release: true but got: " + manifest.getValue(Attributes.Name.MULTI_RELEASE)
+}


### PR DESCRIPTION
Adds an integration test that verifies the `Multi-Release: true` manifest entry is added when the class output contains `META-INF/versions/` files.

The detection logic in `AbstractJarMojo` uses `File.separatorChar` to build the path prefix, which matches the platform separator used by `DirectoryScanner`. This test passes on all platforms (Linux, macOS, Windows).