### PR TITLE
Build against Maven 4.0.0-rc-6

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -26,6 +26,6 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
-      ff-maven: "4.0.0-rc-4"                     # Maven version for fail-fast-build
-      maven-matrix: '[ "4.0.0-rc-4" ]'
+      ff-maven: "4.0.0-rc-6"                     # Maven version for fail-fast-build
+      maven-matrix: '[ "4.0.0-rc-6" ]'
       jdk-matrix: '[ "17", "21" ]'

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 
   <properties>
     <javaVersion>17</javaVersion>
-    <mavenVersion>4.0.0-rc-4</mavenVersion>
+    <mavenVersion>4.0.0-rc-6</mavenVersion>
 
     <guiceVersion>5.1.0</guiceVersion>
     <junitVersion>5.14.4</junitVersion>

--- a/src/test/java/org/apache/maven/plugins/jar/JarMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jar/JarMojoTest.java
@@ -18,9 +18,9 @@
  */
 package org.apache.maven.plugins.jar;
 
-import org.apache.maven.api.plugin.testing.Basedir;
-import org.apache.maven.api.plugin.testing.InjectMojo;
-import org.apache.maven.api.plugin.testing.MojoTest;
+import org.apache.maven.testing.plugin.Basedir;
+import org.apache.maven.testing.plugin.InjectMojo;
+import org.apache.maven.testing.plugin.MojoTest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
Moves `mavenVersion` to the current RC and pins the same version explicitly in the Verify workflow, so CI no longer depends on the `maven4-version` default in maven-gh-actions-shared.

The version bump alone made `JarMojoTest` fail:

```
JarMojoTest.jarTestEnvironment:48 expected: <foo> but was: <myGroupId>
```

rc-6 relocated `org.apache.maven.api.plugin.testing` to `org.apache.maven.testing.plugin`. The old names survive as deprecated shims, so the test still compiled — but `MojoExtension`'s annotation lookup only recognises the new annotation types. With the old ones the `@InjectMojo` attributes come back null, the `@Basedir` pom is never read, and the mojo is handed `MojoExtension`'s built-in default model. Pointing the imports at the new package restores it; no production code changes.

Worth flagging generally: this is a silent behavioural break, not a compile error, so any plugin still importing the deprecated package will keep building and quietly stop reading its test poms. Same relocation as apache/maven-compiler-plugin#1104.

Part of apache/maven#12676. Verified green on a fork before opening.