### PR TITLE
Pass siteMvn as a String so the site stage runs on Maven 4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-asfMavenTlpPlgnBuild(jdks:[ "17", "21" ], maven: [ "4.0.x" ], siteJdk:[ "17" ], siteMvn:[ "4.0.x" ])
+asfMavenTlpPlgnBuild(jdks:[ "17", "21" ], maven: [ "4.0.x" ], siteJdk:[ "17" ], siteMvn: "4.0.x" )


### PR DESCRIPTION
`siteMvn` is passed to `doCreateTask` whole, while `maven` is iterated:

```groovy
for (def mvn in mavens) { ... doCreateTask(os, jdk, mvn, ...) }      // maven: a List is correct
...
doCreateTask( os, jdk, siteMvn, tasks, first, 'site', taskContext )   // siteMvn passed whole
```

and `doCreateTask` does `jenkinsEnv.mvnFromVersion(os, "${maven}")`. A Groovy List stringifies to the literal `"[4.0.x]"`, which matches no `case` in `mvnFromVersion` and falls through to `default: return 'maven_3_latest'`. It is not null either, so the `mvnName == null` skip never fires — the site stage just quietly runs Maven 3.

`maven: [ "4.0.x" ]` stays a List; only `siteMvn` needs to be a String. apache/maven-deploy-plugin already does it this way.

Verified by reading the shared library, not by running a build — the pipeline cannot be executed locally. It also does not make Jenkins green on its own: `maven_4_latest` still resolves to 4.0.0-rc-5 on the build nodes. This makes the configuration do what it already says.

Same fix as apache/maven-clean-plugin#331.