### PR TITLE
Restore the document metadata dropped when the pages were ported

### DIFF
--- a/src/site/markdown/examples/attached-jar.md.vm
+++ b/src/site/markdown/examples/attached-jar.md.vm
@@ -1,3 +1,10 @@
+---
+title: How to create an additional attached jar artifact from the project
+author: 
+  - Karl Heinz Marbaise
+date: 2014-06-16
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/create-test-jar.md.vm
+++ b/src/site/markdown/examples/create-test-jar.md.vm
@@ -1,3 +1,10 @@
+---
+title: How to create a jar containing test classes
+author: 
+  - Karl Heinz Marbaise
+date: 2014-06-16
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/include-exclude.md.vm
+++ b/src/site/markdown/examples/include-exclude.md.vm
@@ -1,3 +1,10 @@
+---
+title: Howto include/exclude content from a jar archive
+author: 
+  - Karl Heinz Marbaise
+date: 2014-06-16
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/manifest-customization.md.vm
+++ b/src/site/markdown/examples/manifest-customization.md.vm
@@ -1,3 +1,10 @@
+---
+title: Manifest customization
+author: 
+  - Dennis Lundberg
+date: 2006-07-12
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Introduction
+author: 
+  - Dennis Lundberg
+date: 2013-07-22
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -1,3 +1,13 @@
+---
+title: Usage
+author: 
+  - Jerome Lacoste
+  - Dennis Lundberg
+  - Olivier Lamy
+  - Karl Heinz Marbaise
+date: 2016-06-03
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
The site pages lost their document metadata when they were ported from APT.

An APT document opens with a header block giving its title, authors and date, and
`doxia-converter` turns that into YAML front matter. The port dropped the front matter
along with the converter's per-line licence comments, so the generated pages lost their
`<meta name="author">` and date, and took their `<title>` from the first heading instead
of from the document title.

Building one project's site from the APT sources and from the ported Markdown shows the
difference:

| | `<title>` produced |
|---|---|
| APT original | `Release Notes - Modello` |
| ported Markdown | `Modello - Modello` |
| with this change | `Release Notes - Modello` |

The front matter has to come first in the file, because the Markdown parser only looks
for it when the source begins with `---`; a licence header ahead of it would hide it.
RAT is happy either way.

Verified by building the site before and after and comparing `<title>` and the author
meta tags of every generated page, and by confirming the front matter does not reach
the rendered body.