### PR TITLE
Render the archive parameter as code on the FAQ page

### DIFF
--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -28,7 +28,7 @@ under the License.
       <question>Why is there no documentation for the archive parameter?</question>
       <answer>
         <p>
-          The `archive` parameter is defined by the Maven Archiver library.
+          The <code>archive</code> parameter is defined by the Maven Archiver library,
           not by the Maven JAR Plugin. Read the <a href="/shared/maven-archiver/index.html">Maven Archiver
           documentation</a>.
         </p>


### PR DESCRIPTION
### The problem

`src/site/fml/faq.fml` currently writes the parameter name with Markdown backticks:

```xml
<p>
  The `archive` parameter is defined by the Maven Archiver library.
  not by the Maven JAR Plugin. ...
</p>
```

FML is not Markdown. An `<answer>` body is handed to Doxia's `XdocParser`
([`FmlParser.java:471,510`](https://github.com/apache/maven-doxia/blob/master/doxia-modules/doxia-module-fml/src/main/java/org/apache/maven/doxia/module/fml/FmlParser.java)),
which has no backtick handling, so the characters land on the generated page verbatim.
Line 125 of the built `faq.html`:

```html
The `archive` parameter is defined by the Maven Archiver library. not by the Maven JAR Plugin. Read the <a href="/shared/maven-archiver/index.html">Maven Archiver documentation</a>.
```

**This is a pre-existing bug, not one this PR introduces.** It arrived with the
Simplified Technical English rewrite in #581, where the Markdown convention was applied
to an FML file. This is the only `faq.fml` in the Maven estate using backticks; 22 others
use `<code>`, which is what this PR switches to.

The same sentence also picked up a full stop where a comma belongs, splitting
"defined by the Maven Archiver library, not by the Maven JAR Plugin" into a sentence and
a fragment. Fixed here because it is the same sentence from the same rewrite.

### Verification

Built the site with `mvn site` before and after and compared the rendered pages. The only
differences a reader would see:

```
27c27          35c35
< `archive`    < library.
---            ---
> archive      > library,
```

The `#question1` anchor is unchanged, so existing deep links keep working.

<sub>Drafted with Claude — please verify</sub>
