### PR TITLE
Skip empty JARs when includes match no files #510

### DIFF
--- a/src/it/MJAR-510/pom.xml
+++ b/src/it/MJAR-510/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-jar-plugin-test-mjar-510</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+  <name>Maven</name>
+  <description>skipIfEmpty should skip when includes match no files</description>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>junit</id>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+            <configuration>
+              <classifier>junit</classifier>
+              <skipIfEmpty>true</skipIfEmpty>
+              <includes>
+                <include>**/junit/*</include>
+              </includes>
+              <excludes>
+                <exclude>**/*Test.class</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/MJAR-510/src/main/java/my/org/app1/App1.java
+++ b/src/it/MJAR-510/src/main/java/my/org/app1/App1.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package my.org.app1;
+
+public class App1 {}

--- a/src/it/MJAR-510/src/test/java/my/org/app1/App1Test.java
+++ b/src/it/MJAR-510/src/test/java/my/org/app1/App1Test.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package my.org.app1;
+
+public class App1Test {}

--- a/src/it/MJAR-510/verify.bsh
+++ b/src/it/MJAR-510/verify.bsh
@@ -1,0 +1,53 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+
+try
+{
+    File target = new File( basedir, "target" );
+    if ( !target.exists() || !target.isDirectory() )
+    {
+        System.err.println( "target file is missing or not a directory." );
+        return false;
+    }
+
+    File artifact = new File( target, "maven-jar-plugin-test-mjar-510-1.0.jar" );
+    if ( !artifact.exists() || artifact.isDirectory() )
+    {
+        System.err.println( "main artifact is missing or a directory." );
+        return false;
+    }
+
+    File junitArtifact = new File( target, "maven-jar-plugin-test-mjar-510-1.0-junit.jar" );
+    if ( junitArtifact.exists() )
+    {
+        System.err.println( "junit classifier jar should not exist when includes match no files." );
+        return false;
+    }
+    return true;
+}
+catch( Throwable e )
+{
+    e.printStackTrace();
+    return false;
+}
+
+return false;

--- a/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
@@ -19,14 +19,12 @@
 package org.apache.maven.plugins.jar;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.jar.Attributes;
-import java.util.stream.Stream;
 
 import org.apache.maven.api.ProducedArtifact;
 import org.apache.maven.api.Project;
@@ -38,7 +36,6 @@ import org.apache.maven.api.plugin.annotations.Parameter;
 import org.apache.maven.api.services.ProjectManager;
 import org.apache.maven.shared.archiver.MavenArchiveConfiguration;
 import org.apache.maven.shared.archiver.MavenArchiver;
-import org.apache.maven.shared.archiver.MavenArchiverException;
 import org.apache.maven.shared.model.fileset.FileSet;
 import org.apache.maven.shared.model.fileset.util.FileSetManager;
 import org.codehaus.plexus.archiver.Archiver;
@@ -119,7 +116,7 @@ public abstract class AbstractJarMojo implements org.apache.maven.api.plugin.Moj
      * This plugin can not detect the post-processing, and so leaves the post-processed JAR file in place.
      * This can lead to failures when those plugins do not expect to find their own output as an input.
      * Set this parameter to {@code true} to recreate the JAR every time.
-     * When {@link #skipIfEmpty} is {@code true} and the classes directory is empty, packaging is skipped even if
+     * When {@link #skipIfEmpty} is {@code true} and no files would be included, packaging is skipped even if
      * {@code forceCreation} is true.
      *
      * <p>Starting with <b>3.0.0</b> the property has been renamed from {@code jar.forceCreation}
@@ -130,8 +127,8 @@ public abstract class AbstractJarMojo implements org.apache.maven.api.plugin.Moj
 
     /**
      * Skip creating empty archives.
-     * When {@code true}, packaging is skipped if the classes directory is empty, even if {@link #forceCreation} is also
-     * {@code true}.
+     * When {@code true}, packaging is skipped if the classes directory is empty or if no files match the configured
+     * includes/excludes, even if {@link #forceCreation} is also {@code true}.
      */
     @Parameter(defaultValue = "false")
     protected boolean skipIfEmpty;
@@ -239,13 +236,7 @@ public abstract class AbstractJarMojo implements org.apache.maven.api.plugin.Moj
                 finalName != null ? finalName : project.getBuild().getFinalName();
         Path jarFile = getJarFile(basedir, resultFinalName, getClassifier());
 
-        FileSetManager fileSetManager = new FileSetManager();
-        FileSet jarContentFileSet = new FileSet();
-        jarContentFileSet.setDirectory(getClassesDirectory().toAbsolutePath().toString());
-        jarContentFileSet.setIncludes(Arrays.asList(getIncludes()));
-        jarContentFileSet.setExcludes(Arrays.asList(getExcludes()));
-
-        String[] includedFiles = fileSetManager.getIncludedFiles(jarContentFileSet);
+        String[] includedFiles = getIncludedFiles();
 
         if (detectMultiReleaseJar
                 && Arrays.stream(includedFiles)
@@ -305,7 +296,7 @@ public abstract class AbstractJarMojo implements org.apache.maven.api.plugin.Moj
      */
     @Override
     public void execute() throws MojoException {
-        if (skipIfEmpty && isEmpty(getClassesDirectory())) {
+        if (skipIfEmpty && hasNoFilesToInclude()) {
             getLog().info(String.format("Skipping packaging of the %s.", getType()));
         } else {
             Path jarFile = createArchive();
@@ -335,15 +326,27 @@ public abstract class AbstractJarMojo implements org.apache.maven.api.plugin.Moj
         }
     }
 
-    private static boolean isEmpty(Path directory) {
-        if (!Files.isDirectory(directory)) {
-            return true;
+    /**
+     * {@return true} if the classes directory is missing or if includes/excludes select no files.
+     */
+    private boolean hasNoFilesToInclude() {
+        return getIncludedFiles().length == 0;
+    }
+
+    /**
+     * Files under the classes directory that match {@link #includes} and {@link #excludes}.
+     */
+    private String[] getIncludedFiles() {
+        Path classesDirectory = getClassesDirectory();
+        if (!Files.isDirectory(classesDirectory)) {
+            return new String[0];
         }
-        try (Stream<Path> children = Files.list(directory)) {
-            return children.findAny().isEmpty();
-        } catch (IOException e) {
-            throw new MavenArchiverException("Unable to access directory", e);
-        }
+        FileSetManager fileSetManager = new FileSetManager();
+        FileSet jarContentFileSet = new FileSet();
+        jarContentFileSet.setDirectory(classesDirectory.toAbsolutePath().toString());
+        jarContentFileSet.setIncludes(Arrays.asList(getIncludes()));
+        jarContentFileSet.setExcludes(Arrays.asList(getExcludes()));
+        return fileSetManager.getIncludedFiles(jarContentFileSet);
     }
 
     private boolean projectHasAlreadySetAnArtifact() {


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

`skipIfEmpty` only looked at whether the classes directory had any children. A `test-jar` with includes like `**/junit/*` still wrote a manifest-only archive when those patterns matched nothing, which is the setup in #510.

I reused the existing FileSet scan so skipIfEmpty also treats "no matching files" as empty. MJAR-162 still skips a missing test-classes directory. MJAR-510 covers the includes case.
