### PR TITLE
More robust change detection

### DIFF
--- a/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java
@@ -120,15 +120,21 @@ public abstract class AbstractJarMojo implements org.apache.maven.api.plugin.Moj
     private PathMatcherFactory matcherFactory;
 
     /**
-     * Require the jar plugin to build new <abbr>JAR</abbr> files even if none of the contents appear to have changed.
+     * Require the JAR plugin to build new <abbr>JAR</abbr> files even if none of the contents appear to have changed.
      * By default, this plugin looks to see if the output <abbr>JAR</abbr> files exist and inputs have not changed.
-     * If these conditions are true, the plugin skips creation of the <abbr>JAR</abbr> files.
-     * This does not work when other plugins, like the maven-shade-plugin, are configured to post-process the JAR.
-     * This plugin cannot detect the post-processing, and so leaves the post-processed JAR file in place.
-     * This can lead to failures when those plugins do not expect to find their own output as an input.
-     * Set this parameter to {@code true} to recreate the JAR every time.
-     * When {@link #skipIfEmpty} is {@code true} and the classes directory is empty, packaging is skipped even if
-     * {@code forceCreation} is true.
+     * If these conditions are true, by default the plugin skips creation of the <abbr>JAR</abbr> files.
+     * But if this parameter is {@code true}, change detection is disabled and the JAR will be created every time.
+     * This parameter is ignored if {@link #skipIfEmpty} is {@code true} and there are no files to include in the JAR.
+     *
+     * <p><b>When to use:</b>
+     * Skipping JAR creation does not work when other plugins, like the maven-shade-plugin,
+     * are configured to post-process the JAR. Leaving the post-processed JAR file in place
+     * can lead to failures when those plugins do not expect to find their own output as an input.
+     * Setting this parameter to {@code true} avoids this problem.
+     * Starting with <b>4.0.0-beta-2</b>, setting this parameter can be unnecessary because the JAR plugin
+     * compares also the file lengths and checks if the JAR file contains additional entries.
+     * Nevertheless, it can be safer to set this parameter to {@code true} anyway
+     * when it is certain that post-processing will be applied.</p>
      *
      * <p>Starting with <b>3.0.0</b> the property has been renamed from {@code jar.forceCreation}
      * to {@code maven.jar.forceCreation}.</p>
@@ -138,8 +144,8 @@ public abstract class AbstractJarMojo implements org.apache.maven.api.plugin.Moj
 
     /**
      * Skip creating empty archives.
-     * When {@code true}, packaging is skipped if the classes directory is empty, even if {@link #forceCreation} is also
-     * {@code true}.
+     * When {@code true}, packaging is skipped if there are no files to include,
+     * even if {@link #forceCreation} is also {@code true}.
      */
     @Parameter(defaultValue = "false")
     protected boolean skipIfEmpty;

--- a/src/main/java/org/apache/maven/plugins/jar/TimestampCheck.java
+++ b/src/main/java/org/apache/maven/plugins/jar/TimestampCheck.java
@@ -74,17 +74,24 @@ final class TimestampCheck extends SimpleFileVisitor<Path> {
      * Files found in the <abbr>JAR</abbr> file but not yet traversed by the file visitor.
      * Files are added lazily when needed, and removed as soon as they have been traversed.
      * Paths are absolute (resolved with {@link #classesDir}).
-     * For each entry, the associated value is whether the path is a directory.
+     * For each entry, the associated value is the file size, or -1 if unknown,
+     * or {@value #ENTRY_IS_DIRECTORY} if the path is a directory.
      */
-    private final Map<Path, Boolean> filesInJAR;
+    private final Map<Path, Long> filesInJAR;
 
     /**
      * Some of the files in the build directory. This list contains only the files for which we have already
-     * verified the timestamp. We store them in a separate list to avoid checking to check the timestamp twice.
-     * We need this list because we still need to verify if the files are in the {@link #jarFile}.
-     * For each entry, the associated value is whether the path is a directory.
+     * verified the timestamp. We store them in a separate map to avoid to check the timestamp twice.
+     * We need this map because we still need to verify if the files are in the {@link #jarFile}.
+     * For each entry, the associated value is the file size, or -1 if unknown,
+     * or {@value #ENTRY_IS_DIRECTORY} if the path is a directory.
      */
-    private final Map<Path, Boolean> filesInBuild;
+    private final Map<Path, Long> filesInBuild;
+
+    /**
+     * Sentinel value for {@link #filesInJAR} entries that are directories.
+     */
+    private static final long ENTRY_IS_DIRECTORY = -2;
 
     /**
      * Whether at least one file is more recent than the <abbr>JAR</abbr> file.
@@ -122,7 +129,7 @@ final class TimestampCheck extends SimpleFileVisitor<Path> {
         if (jarFileTime.compareTo(attributes.lastModifiedTime()) < 0) {
             return true;
         }
-        filesInBuild.put(file, isDirectory);
+        filesInBuild.put(file, isDirectory ? ENTRY_IS_DIRECTORY : attributes.size());
         return false;
     }
 
@@ -136,22 +143,22 @@ final class TimestampCheck extends SimpleFileVisitor<Path> {
         // No need to use JarFile because no need to handle META-INF in a special way.
         try (ZipFile jar = new ZipFile(jarFile.toFile())) {
             entries = jar.entries();
-            for (Path file : filesInBuild.keySet()) {
-                if (!removeFromFilesInJAR(file)) {
+            for (Map.Entry<Path, Long> entry : filesInBuild.entrySet()) {
+                if (!removeFromFilesInJAR(entry.getKey(), entry.getValue())) {
                     return false;
                 }
             }
-            // Verify the timestamps of files that were not verified by `isUpdate(…)`.
+            // Verify the timestamps of files that were not verified by `isUpdated(…)`.
             for (Archive.FileSet fileSet : fileSets) {
                 Path directory = null;
                 for (Path file : fileSet.files) {
-                    final Boolean isDirectory = filesInBuild.remove(file);
-                    if (isDirectory == null) { // For skipping the files already verified by the first loop.
+                    final Long size = filesInBuild.remove(file);
+                    if (size == null) { // For skipping the files already verified by the first loop.
                         if (hasUpdatedInSubdir(directory)) {
                             return false;
                         }
                         directory = null;
-                    } else if (isDirectory) {
+                    } else if (size == ENTRY_IS_DIRECTORY) {
                         // Because of files order, it is sufficient to remember only the last directory.
                         directory = file;
                     }
@@ -161,8 +168,8 @@ final class TimestampCheck extends SimpleFileVisitor<Path> {
                 }
             }
             // Check for remaining files in the JAR which were not in the build directory.
-            for (Map.Entry<Path, Boolean> entry : filesInJAR.entrySet()) {
-                if (!(entry.getValue() || isIgnored(classesDir.relativize(entry.getKey())))) {
+            for (Map.Entry<Path, Long> entry : filesInJAR.entrySet()) {
+                if (!(entry.getValue() == ENTRY_IS_DIRECTORY || isIgnored(classesDir.relativize(entry.getKey())))) {
                     return false;
                 }
             }
@@ -228,7 +235,8 @@ final class TimestampCheck extends SimpleFileVisitor<Path> {
      */
     @Override
     public FileVisitResult visitFile(final Path file, final BasicFileAttributes attributes) {
-        if (jarFileTime.compareTo(attributes.lastModifiedTime()) >= 0 && removeFromFilesInJAR(file)) {
+        if (jarFileTime.compareTo(attributes.lastModifiedTime()) >= 0
+                && removeFromFilesInJAR(file, attributes.size())) {
             return FileVisitResult.CONTINUE;
         } else {
             hasUpdates = true;
@@ -239,13 +247,16 @@ final class TimestampCheck extends SimpleFileVisitor<Path> {
     /**
      * Returns whether the given file is found in the <abbr>JAR</abbr> file.
      * If the file is found, it is removed from the {@link #filesInJAR} map.
+     * This method also verifies that the file in the JAR has the expected length.
      *
      * @param file the file to check
+     * @param size file size in bytes, or negative if unknown or not applicable
      * @return whether the given file was found in the <abbr>JAR</abbr> file
      */
-    private boolean removeFromFilesInJAR(final Path file) {
-        if (filesInJAR.remove(file) != null) {
-            return true;
+    private boolean removeFromFilesInJAR(final Path file, final long size) {
+        Long sizeInJAR = filesInJAR.remove(file);
+        if (sizeInJAR != null) {
+            return (size < 0) || (sizeInJAR < 0) || (size == sizeInJAR);
         }
         while (entries.hasMoreElements()) {
             ZipEntry entry = entries.nextElement();
@@ -253,7 +264,7 @@ final class TimestampCheck extends SimpleFileVisitor<Path> {
             if (p.equals(file)) {
                 return true;
             }
-            filesInJAR.put(p, entry.isDirectory());
+            filesInJAR.put(p, entry.isDirectory() ? ENTRY_IS_DIRECTORY : entry.getSize());
         }
         return false;
     }

--- a/src/main/java/org/apache/maven/plugins/jar/TimestampCheck.java
+++ b/src/main/java/org/apache/maven/plugins/jar/TimestampCheck.java
@@ -89,9 +89,32 @@ final class TimestampCheck extends SimpleFileVisitor<Path> {
     private final Map<Path, Long> filesInBuild;
 
     /**
-     * Sentinel value for {@link #filesInJAR} entries that are directories.
+     * Sentinel length stored in {@link #filesInJAR}/{@link #filesInBuild} for entries that are directories.
+     * Directories have no meaningful length to compare.
      */
     private static final long ENTRY_IS_DIRECTORY = -2;
+
+    /**
+     * {@return whether the given encoded length denotes a directory entry}
+     *
+     * @param size an encoded length from {@link #filesInJAR} or {@link #filesInBuild}
+     */
+    private static boolean isDirectory(final long size) {
+        return size == ENTRY_IS_DIRECTORY;
+    }
+
+    /**
+     * {@return whether two entry lengths are considered equal for change detection}
+     * A negative length cannot be compared — it denotes either a directory ({@value #ENTRY_IS_DIRECTORY})
+     * or an unknown size (e.g. {@link ZipEntry#getSize()} returned -1) — so it is treated as a match.
+     * Two known (non-negative) lengths must be equal.
+     *
+     * @param a the length of the file in the build directory, or a negative sentinel
+     * @param b the length of the corresponding entry in the <abbr>JAR</abbr>, or a negative sentinel
+     */
+    private static boolean sizesMatch(final long a, final long b) {
+        return a < 0 || b < 0 || a == b;
+    }
 
     /**
      * Whether at least one file is more recent than the <abbr>JAR</abbr> file.
@@ -158,7 +181,7 @@ final class TimestampCheck extends SimpleFileVisitor<Path> {
                             return false;
                         }
                         directory = null;
-                    } else if (size == ENTRY_IS_DIRECTORY) {
+                    } else if (isDirectory(size)) {
                         // Because of files order, it is sufficient to remember only the last directory.
                         directory = file;
                     }
@@ -169,7 +192,7 @@ final class TimestampCheck extends SimpleFileVisitor<Path> {
             }
             // Check for remaining files in the JAR which were not in the build directory.
             for (Map.Entry<Path, Long> entry : filesInJAR.entrySet()) {
-                if (!(entry.getValue() == ENTRY_IS_DIRECTORY || isIgnored(classesDir.relativize(entry.getKey())))) {
+                if (!(isDirectory(entry.getValue()) || isIgnored(classesDir.relativize(entry.getKey())))) {
                     return false;
                 }
             }
@@ -256,15 +279,16 @@ final class TimestampCheck extends SimpleFileVisitor<Path> {
     private boolean removeFromFilesInJAR(final Path file, final long size) {
         Long sizeInJAR = filesInJAR.remove(file);
         if (sizeInJAR != null) {
-            return (size < 0) || (sizeInJAR < 0) || (size == sizeInJAR);
+            return sizesMatch(size, sizeInJAR);
         }
         while (entries.hasMoreElements()) {
             ZipEntry entry = entries.nextElement();
             Path p = classesDir.resolve(entry.getName());
+            long entrySize = entry.isDirectory() ? ENTRY_IS_DIRECTORY : entry.getSize();
             if (p.equals(file)) {
-                return true;
+                return sizesMatch(size, entrySize);
             }
-            filesInJAR.put(p, entry.isDirectory() ? ENTRY_IS_DIRECTORY : entry.getSize());
+            filesInJAR.put(p, entrySize);
         }
         return false;
     }


### PR DESCRIPTION
Modify the documentation about `forceCreation` and `skipIfEmpty` for taking in account the fact that the new JAR plugin implementation also verify if the JAR files has more files than expected, which cover the Shape plugin case documented as a reason for the `forceCreation` option.

Also add file length comparaison when detecting changes in order to increase the validity of the new `forceCreation` documentation, which said that while supported, this option is often not necessary. 

Edit the documentation of `skipIfEmpty` because this option skips the JAR file creation not only if the directory does not exist, but also if no input files are matched for inclusion.

This pull request complement #585.